### PR TITLE
Improve tag show speed

### DIFF
--- a/Yuuka/Database/Db.cs
+++ b/Yuuka/Database/Db.cs
@@ -114,9 +114,9 @@ namespace Yuuka.Database
                 return null;
             var tag = _globalTags[key];
             tag.NbUsage++;
-            await _r.Db(_dbName).Table("Tags").Update(_r.HashMap("id", tag.id)
+            _r.Db(_dbName).Table("Tags").Update(_r.HashMap("id", tag.id)
                 .With("NbUsage", tag.NbUsage)
-            ).RunAsync(_conn);
+            ).RunNoReply(_conn);
             return _globalTags[key];
         }
 


### PR DESCRIPTION
The `SendTag(...)` function will now no longer wait for the count update query to finish and continue right away to show the tag which results in a performance boost.